### PR TITLE
Add abbreviations for common licenses

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -27,7 +27,8 @@ sys.path.insert(0, os.path.abspath('.'))
 from acronyms import acronyms # This includes things like |HRTF| etc.
 from replacements import replacements # This includes |TwoEarsModel| etc.
 from links import links # This includes url links
-rst_epilog = acronyms + replacements + links # Apply those to every page
+from licenses import licenses # This includes acronyms for licenses
+rst_epilog = acronyms + replacements + links + licenses # Apply those to every page
 
 
 # -- General configuration ------------------------------------------------

--- a/database/impulse-responses/brirs.txt
+++ b/database/impulse-responses/brirs.txt
@@ -20,7 +20,7 @@ Digital Object Identifier
 License
 ^^^^^^^
 
-`Creative Commons Attribution 4.0 <https://creativecommons.org/licenses/by/4.0/>`_
+|CC BY 4.0|
 
 Description
 ^^^^^^^^^^^
@@ -98,7 +98,7 @@ Digital Object Identifier
 License
 ^^^^^^^
 
-`Creative Commons Attribution 4.0 <https://creativecommons.org/licenses/by/4.0/>`_
+|CC BY 4.0|
 
 Description
 ^^^^^^^^^^^
@@ -171,7 +171,7 @@ Digital Object Identifier
 License
 ^^^^^^^
 
-`Creative Commons Attribution 4.0 <https://creativecommons.org/licenses/by/4.0/>`_
+|CC BY 4.0|
 
 Description
 ^^^^^^^^^^^
@@ -243,7 +243,7 @@ Digital Object Identifier
 License
 ^^^^^^^
 
-`Creative Commons Attribution-ShareAlike 4.0 <https://creativecommons.org/licenses/by-sa/3.0/>`_
+|CC BY-SA 3.0|
 
 Description
 ^^^^^^^^^^^
@@ -290,7 +290,7 @@ Digital Object Identifier
 License
 ^^^^^^^
 
-`Creative Commons Attribution 4.0 <https://creativecommons.org/licenses/by/4.0/>`_
+|CC BY 4.0|
 
 Description
 ^^^^^^^^^^^
@@ -345,17 +345,17 @@ Single-channel impulse responses:
 		impulse_responses/uro_kemar_audiolab/rirs/RIR_NoCeilingAbsorbers_ArrayCentre_Emitters1to64.sofa
 		impulse_responses/uro_kemar_audiolab/rirs/RIR_NoCeilingAbsorbers_OffCentre_Emitters1to64.sofa
 		impulse_responses/uro_kemar_audiolab/rirs/RIR_NoCeilingAbsorbers_RoomCentre_Emitters1to64.sofa
-	
+
 
 .. _sec-brir-bbc:
-	
+
 Salford-BBC, 12-channel loudspeaker studio
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		
+
 License
 ^^^^^^^
 
-`Creative Commons Attribution-NonCommercial-ShareAlike 4.0 <https://creativecommons.org/licenses/by-nc-sa/4.0/>`_
+|CC BY-NC-SA 4.0|
 
 Description
 ^^^^^^^^^^^
@@ -370,9 +370,9 @@ in 2° steps at each position. Additional information can be found at the
 .. figure:: ../img/brir_bbc_bk_salford_setup.jpg
     :width: 50 %
     :align: center
-    
+
     Measurement layout.
-    
+
 ::
 
 		impulse_responses/bbc_bk_salford/SBSBRIR_x-0pt5y-0pt5.sofa
@@ -400,7 +400,7 @@ University of Surrey, four different rooms
 License
 ^^^^^^^
 
-Copyright (c) 2016 Institute of Sound Recording under `The MIT License <https://opensource.org/licenses/MIT>`_
+Copyright (c) 2016 Institute of Sound Recording under |MIT|
 
 Description
 ^^^^^^^^^^^

--- a/database/impulse-responses/hrirs.txt
+++ b/database/impulse-responses/hrirs.txt
@@ -20,7 +20,7 @@ Digital Object Identifier
 License
 ^^^^^^^
 
-`Creative Commons Attribution-NonCommercial-ShareAlike 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0/>`_
+|CC BY-NC-SA 3.0|
 
 Description
 ^^^^^^^^^^^
@@ -52,7 +52,6 @@ The measurement comes also with the following headphone compensation filters::
     impulse_responses/qu_kemar_anechoic/QU_KEMAR_AKGK271_hcomp.wav
     impulse_responses/qu_kemar_anechoic/QU_KEMAR_AKGK601_hcomp.wav
     impulse_responses/qu_kemar_anechoic/QU_KEMAR_SennheiserHD25_hcomp.wav
-    
 
 .. [Wierstorf2011]
     Wierstorf, H., Geier, M., Raake, A., Spors, S. (2011) "A Free Database of
@@ -67,7 +66,7 @@ Spherical far-field |HRTF| compilation of the Neumann KU100
 License
 ^^^^^^^
 
-`Creative Commons Attribution-ShareAlike 3.0 <https://creativecommons.org/licenses/by-sa/3.0/>`_
+|CC BY-SA 3.0|
 
 Description
 ^^^^^^^^^^^

--- a/database/listening-tests/quality-ratings.txt
+++ b/database/listening-tests/quality-ratings.txt
@@ -43,6 +43,12 @@ Digital Object Identifier
 - Stimuli: `doi: 10.14279/depositonce-5173 <https://doi.org/10.14279/depositonce-5173>`_
 - Results: `doi: 10.5281/zenodo.164433 <https://doi.org/10.5281/zenodo.164433>`_
 
+License
+^^^^^^^
+
+- Stimuli: |CC BY-NC-SA 4.0|
+- Results: |CC BY 4.0|
+
 Description
 ^^^^^^^^^^^
 
@@ -111,6 +117,11 @@ Digital Object Identifier
 
 - Stimuli: `doi: 10.5281/zenodo.61000 <https://doi.org/10.5281/zenodo.61000>`_
 - Results: `doi: 10.5281/zenodo.162161 <https://doi.org/10.5281/zenodo.162161>`_
+
+License
+^^^^^^^
+
+|CC BY 4.0|
 
 Description
 ^^^^^^^^^^^

--- a/licenses.py
+++ b/licenses.py
@@ -1,0 +1,20 @@
+licenses = """
+.. |CC BY 3.0|              replace:: `Creative Commons Attribution 3.0`_
+.. |CC BY-NC 3.0|           replace:: `Creative Commons Attribution-NonCommercial 3.0`_
+.. |CC BY-SA 3.0|           replace:: `Creative Commons Attribution-ShareAlike 3.0`_
+.. |CC BY-NC-SA 3.0|        replace:: `Creative Commons Attribution-NonCommercial-ShareAlike 3.0`_
+.. |CC BY 4.0|              replace:: `Creative Commons Attribution 4.0`_
+.. |CC BY-NC 4.0|           replace:: `Creative Commons Attribution-NonCommercial 4.0`_
+.. |CC BY-SA 4.0|           replace:: `Creative Commons Attribution-ShareAlike 4.0`_
+.. |CC BY-NC-SA 4.0|        replace:: `Creative Commons Attribution-NonCommercial-ShareAlike 4.0`_
+.. |MIT|                    replace:: `The MIT License`_
+.. _Creative Commons Attribution 3.0: https://creativecommons.org/licenses/by/3.0/
+.. _Creative Commons Attribution-NonCommercial 3.0: https://creativecommons.org/licenses/by-nc/3.0/
+.. _Creative Commons Attribution-ShareAlike 3.0: https://creativecommons.org/licenses/by-sa/3.0/
+.. _Creative Commons Attribution-NonCommercial-ShareAlike 3.0: https://creativecommons.org/licenses/by-nc-sa/3.0/
+.. _Creative Commons Attribution 4.0: https://creativecommons.org/licenses/by/4.0/
+.. _Creative Commons Attribution-NonCommercial 4.0: https://creativecommons.org/licenses/by-nc/4.0/
+.. _Creative Commons Attribution-ShareAlike 4.0: https://creativecommons.org/licenses/by-sa/4.0/
+.. _Creative Commons Attribution-NonCommercial-ShareAlike 4.0: https://creativecommons.org/licenses/by-nc-sa/4.0/
+.. _The MIT License: https://opensource.org/licenses/MIT
+"""


### PR DESCRIPTION
As we have to add quite often CC licenses I created the shortcuts ``|CC BY-SA 4.0|`` and so on.
@fietew I hope you find this helpful, too.